### PR TITLE
[GYCCP-31] ci: deploy actions의 vercel inputs token 수정

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -48,11 +48,11 @@ runs:
       run: ${{ inputs.build-commands }}
 
     - name: Upload build output to Vercel Cloud
-      uses: amondnet/vercel-action@v25
+      uses: amondnet/vercel-action@v25.1.0
       with:
-        vercel-token: ${{ inputs.VERCEL_TOKEN }}
-        vercel-org-id: ${{ inputs.ORG_ID}}
-        vercel-project-id: ${{ inputs.PROJECT_ID}}
-        scope: ${{ inputs.ORG_ID }}
+        vercel-token: ${{ inputs.vercel-token }}
+        vercel-org-id: ${{ inputs.vercel-org-id }}
+        vercel-project-id: ${{ inputs.vercel-project-id }}
+        scope: ${{ inputs.vercel-org-id }}
         github-comment: true
-        github-token: ${{ inputs.GITHUB_TOKEN }}
+        github-token: ${{ inputs.github-token }}


### PR DESCRIPTION
- [GYCCP-31](https://jkpark104.atlassian.net/jira/software/projects/GYCCP/boards/3?selectedIssue=GYCCP-31)
- VERCEL_TOKEN -> vercel-token
- ORG_ID -> vercel-org-id
- PROJECT_ID -> vercel-project-id
- GITHUB_TOKEN -> github-token